### PR TITLE
Fix deactivate task: FK constraint and heredoc over SSH

### DIFF
--- a/src/tasks.php
+++ b/src/tasks.php
@@ -462,7 +462,9 @@ task('lameco:deactivate', function (): void {
 
             // Drop all tables but keep the database itself
             $dropCmd = 'MYSQL_PWD=' . $passEnv . ' mysqldump --no-data -u ' . $userArg . ' ' . $dbArg
-                . ' | grep "^DROP" | MYSQL_PWD=' . $passEnv . ' mysql -u ' . $userArg . ' ' . $dbArg;
+                . ' | grep "^DROP"'
+                . ' | (echo "SET FOREIGN_KEY_CHECKS=0;"; cat; echo "SET FOREIGN_KEY_CHECKS=1;")'
+                . ' | MYSQL_PWD=' . $passEnv . ' mysql -u ' . $userArg . ' ' . $dbArg;
             run($dropCmd);
             writeln('  Alle tabellen in "' . $dbName . '" verwijderd.');
         });
@@ -557,7 +559,8 @@ task('lameco:deactivate', function (): void {
         </html>
         HTML;
 
-    run('cat > ' . $placeholderPath . '/index.html << ' . escapeshellarg('LAMECO_PLACEHOLDER_EOF') . "\n" . $placeholderHtml . "\nLAMECO_PLACEHOLDER_EOF");
+    $encodedHtml = base64_encode($placeholderHtml);
+    run('echo ' . escapeshellarg($encodedHtml) . ' | base64 -d > ' . $placeholderPath . '/index.html');
     writeln('  Placeholder pagina geplaatst.');
 
     // 6. Restart PHP-FPM


### PR DESCRIPTION
## Summary

- **Foreign key constraint fix**: Wraps DROP statements with `SET FOREIGN_KEY_CHECKS=0/1` so tables with FK relationships can be dropped in any order
- **Heredoc over SSH fix**: Replaces broken heredoc placeholder creation (`cat > file << 'EOF'`) with base64 encode/decode to avoid shell escaping issues over SSH transport

## Context

Both bugs were discovered during a staging deactivation of alltech-website:
1. First attempt failed on `ERROR 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails`
2. Second attempt (without DB wipe) failed on `bash: syntax error: unexpected end of file` from the heredoc