### PR TITLE
Fix uploaded asset directory permissions

### DIFF
--- a/src/tasks.php
+++ b/src/tasks.php
@@ -266,6 +266,7 @@ task('lameco:upload_assets', function (): void {
 
             writeln('Uploading assets directory: ' . $dir . '...');
             upload($localDir, $remoteDir);
+            run('chmod -R 755 ' . $remoteDir);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `chmod -R 755` after each directory upload in `lameco:upload_assets` to ensure the web server can read the built assets
- Fixes issue where `upload()` creates directories with `700` permissions, making assets inaccessible

## Test plan
- [ ] Deploy any project and verify `public/build/` has `755` permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)