### PR TITLE
feat: add lameco:db_open task to open remote DB in Sequel Ace via SSH tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ Displays remote database credentials.
 
 ---
 
+### lameco:db_open
+
+Opens the remote database of the selected host in [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace), tunneled over SSH with your local SSH key.
+
+- Reads the remote `.env` file and extracts DB user, password, name, host and port (supports Symfony `DATABASE_URL`, Craft `CRAFT_DB_*` and Laravel `DB_*`).
+- Reads SSH host, port and user from the Deployer host config.
+- Resolves the SSH key: uses the host's `identity_file` if set, otherwise falls back to the first existing of `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`.
+- Builds a `mysql://` URL with Sequel Ace's `ssh_*` query parameters and launches it via `open`. Sequel Ace then establishes the tunnel itself.
+- macOS only. Errors out clearly on other platforms or when credentials/SSH key cannot be resolved.
+
+**Example:**
+
+```bash
+dep lameco:db_open staging
+dep lameco:db_open production
+```
+
+**Notes:**
+
+- Sequel Ace must have sandbox access to the SSH key file — grant it in **Settings → Files**.
+- Sequel Ace uses its own strict `ssh_known_hosts` file (under `~/Library/Containers/com.sequel-ace.sequel-ace/Data/.keys/`). On the first connection to a new host, the host key needs to be added — e.g. `ssh-keyscan -p 22 host.example.com >> ~/Library/Containers/com.sequel-ace.sequel-ace/Data/.keys/ssh_known_hosts_strict`.
+
+---
+
 ### lameco:db_upload
 
 Uploads a local database dump to a remote host and imports it.

--- a/src/functions.php
+++ b/src/functions.php
@@ -101,6 +101,72 @@ function extractDbCredentials(array $env): array
 }
 
 /**
+ * Extract database host and port from an environment array.
+ * Supports DATABASE_URL (Symfony), CRAFT_DB_* (Craft CMS), and Laravel style.
+ *
+ * @param array $env Associative array of environment variables.
+ * @return array Array with [host, port] or [null, null] if not found.
+ */
+function extractDbHostPort(array $env): array
+{
+    if (! empty($env['DATABASE_URL'])) {
+        $url = (string) $env['DATABASE_URL'];
+        $parts = parse_url($url);
+        if (is_array($parts) && (! isset($parts['scheme']) || in_array($parts['scheme'], ['mysql', 'mariadb'], true))) {
+            $host = isset($parts['host']) ? rawurldecode($parts['host']) : null;
+            $port = isset($parts['port']) ? (int) $parts['port'] : null;
+            return [$host, $port];
+        }
+    } elseif (! empty($env['CRAFT_DB_DATABASE'])) {
+        return [
+            $env['CRAFT_DB_SERVER'] ?? null,
+            isset($env['CRAFT_DB_PORT']) ? (int) $env['CRAFT_DB_PORT'] : null,
+        ];
+    } elseif (! empty($env['DB_DATABASE'])) {
+        return [
+            $env['DB_HOST'] ?? null,
+            isset($env['DB_PORT']) ? (int) $env['DB_PORT'] : null,
+        ];
+    }
+    return [null, null];
+}
+
+/**
+ * Resolve the SSH identity file to use for a Deployer host.
+ * Falls back to the first existing of ~/.ssh/id_ed25519, ~/.ssh/id_rsa.
+ *
+ * @param \Deployer\Host\Host $host The Deployer host.
+ * @return string|null Absolute path to the identity file, or null if none found.
+ */
+function resolveSshIdentityFile(\Deployer\Host\Host $host): ?string
+{
+    $home = $_SERVER['HOME'] ?? getenv('HOME') ?: null;
+
+    $configured = $host->getIdentityFile();
+    if ($configured !== null && $configured !== '') {
+        if ($home !== null && str_starts_with($configured, '~/')) {
+            $configured = $home . substr($configured, 1);
+        }
+        if (file_exists($configured)) {
+            return $configured;
+        }
+    }
+
+    if ($home === null) {
+        return null;
+    }
+
+    foreach (['id_ed25519', 'id_rsa'] as $name) {
+        $path = $home . '/.ssh/' . $name;
+        if (file_exists($path)) {
+            return $path;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Determine if the given Node.js version supports Corepack.
  *
  * @param string $versionString Node.js version string (e.g. "v16.13.0").

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -153,6 +153,68 @@ task('lameco:db_credentials', function (): void {
     });
 });
 
+// Open the remote database in Sequel Ace via SSH tunnel.
+desc('Open the remote database in Sequel Ace via SSH tunnel');
+task('lameco:db_open', function (): void {
+    if (PHP_OS_FAMILY !== 'Darwin') {
+        error('lameco:db_open requires macOS (uses the `open` command and Sequel Ace URL scheme).');
+        return;
+    }
+
+    $host = currentHost();
+    if (! $host) {
+        error('No host selected.');
+        return;
+    }
+
+    $sshHost = $host->getHostname();
+    $sshUser = $host->getRemoteUser();
+    $sshPort = $host->getPort() ?: 22;
+
+    if (! $sshHost || ! $sshUser) {
+        error('Host is missing hostname or remote user.');
+        return;
+    }
+
+    $sshKey = resolveSshIdentityFile($host);
+    if ($sshKey === null) {
+        error('Could not find an SSH identity file. Set `identity_file` on the host, or place a key at ~/.ssh/id_ed25519 or ~/.ssh/id_rsa.');
+        return;
+    }
+
+    within('{{deploy_path}}/shared', function () use ($sshHost, $sshPort, $sshUser, $sshKey): void {
+        $envContent = run('cat .env');
+        $env = fetchEnv($envContent);
+
+        [$dbUser, $dbPass, $dbName] = extractDbCredentials($env);
+        if (! isset($dbUser, $dbPass, $dbName)) {
+            error('Could not extract remote database credentials.');
+            return;
+        }
+
+        [$dbHost, $dbPort] = extractDbHostPort($env);
+        $dbHost ??= '127.0.0.1';
+        $dbPort ??= 3306;
+
+        $query = http_build_query([
+            'ssh_host' => $sshHost,
+            'ssh_port' => $sshPort,
+            'ssh_user' => $sshUser,
+            'ssh_keyLocation' => $sshKey,
+            'ssh_keyLocationEnabled' => '1',
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        $url = 'mysql://'
+            . rawurlencode((string) $dbUser) . ':' . rawurlencode((string) $dbPass)
+            . '@' . $dbHost . ':' . $dbPort
+            . '/' . rawurlencode((string) $dbName)
+            . '?' . $query;
+
+        writeln('Opening connection in Sequel Ace...');
+        runLocally('open ' . escapeshellarg($url));
+    });
+});
+
 // Upload a local database dump to remote and import it.
 desc('Upload local database dump to remote and import it');
 task('lameco:db_upload', function (): void {


### PR DESCRIPTION
## Summary
- Adds a new Deployer task **`lameco:db_open`** that opens the remote database of a selected host directly in [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace), tunneled over SSH using the developer's local SSH key.
- Adds two supporting helpers in `src/functions.php`:
  - `extractDbHostPort()` — sibling of `extractDbCredentials()` returning `[host, port]` from `DATABASE_URL` / `CRAFT_DB_*` / Laravel-style env.
  - `resolveSshIdentityFile()` — resolves the SSH key path: prefers the Deployer host's `identity_file`, otherwise falls back to the first existing of `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`.

## Why
We frequently need to poke at the staging/production database. The existing `lameco:db_credentials` prints user/password, but you still have to copy them into a GUI and set up the SSH tunnel by hand. Sequel Ace supports a `mysql://` URL scheme with `ssh_*` query parameters (documented in [Sequel-Ace/Sequel-Ace#2341](https://github.com/Sequel-Ace/Sequel-Ace/pull/2341)) — this task wires Deployer's host config and the remote `.env` straight into that scheme so a single `dep lameco:db_open staging` opens a ready-to-use connection.

## How it works
1. Reads remote `.env` from `{{deploy_path}}/shared`.
2. Pulls DB user/password/name via the existing `extractDbCredentials()` and DB host/port via the new `extractDbHostPort()` (defaulting to `127.0.0.1:3306` if not specified).
3. Pulls SSH host/port/user from the Deployer host (`getHostname()`, `getPort()`, `getRemoteUser()`).
4. Resolves the SSH identity file via `resolveSshIdentityFile()`.
5. Builds a percent-encoded URL:
   ```
   mysql://user:pass@dbhost:dbport/dbname?ssh_host=...&ssh_port=...&ssh_user=...&ssh_keyLocation=...&ssh_keyLocationEnabled=1
   ```
6. Runs `open <url>` locally — Launch Services hands it to Sequel Ace, which establishes the tunnel itself.

## Usage
```sh
dep lameco:db_open staging
dep lameco:db_open production
```

## Guardrails
- Errors out on non-macOS (the task depends on the `open` command and Sequel Ace).
- Errors out clearly if no host is selected, the host is missing hostname/remote user, no SSH key can be resolved, or the remote `.env` doesn't yield DB credentials.

## Notes
- Sequel Ace must have sandbox access to the SSH key file (Settings → Files), as documented in the Sequel Ace docs for `mysql://` URLs.
- Sequel Ace also uses its own strict `ssh_known_hosts` file. On the very first connection to a new host, the host key needs to be added (see `~/Library/Containers/com.sequel-ace.sequel-ace/Data/.keys/ssh_known_hosts_strict`).

## Test plan
- [x] `dep lameco:db_open staging` opens a connected Sequel Ace tab against simac-website staging (verified end-to-end).
- [x] `vendor/bin/ecs check src/` passes.
- [x] PHP syntax-clean (`php -l`).
- [ ] Verify on a non-Symfony project type (CraftCMS / Laravel) that `extractDbHostPort()` returns sensible host/port from `CRAFT_DB_*` / `DB_*`.
- [ ] Verify with a host that overrides `identity_file` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)