### PR TITLE
feat!: switch database CLI from mysql/mysqldump to mariadb/mariadb-dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A collection of common tasks for [Deployer](https://deployer.org/) to streamline
 
 - PHP 8.4 or higher
 - Deployer 7.0 or higher
+- MariaDB client tools (`mariadb` and `mariadb-dump`) on every host that runs the database tasks (`lameco:db_download`, `lameco:db_upload`, `lameco:sync`, `lameco:deactivate`) — both locally and on each remote host. The legacy `mysql` / `mysqldump` binaries are no longer invoked; see [Upgrading from 1.x](#upgrading-from-1x).
 
 ## Installation
 
@@ -252,6 +253,23 @@ set('lameco_php_config', 'php-fpm-customuser.service');
 - `lameco:build_assets` expects nvm in `$NVM_DIR` (or `~/.nvm`) and uses `bash -lc` to load it.
 - Supervisor and PHP-FPM restarts are configurable and can be disabled per project.
 - For staging hosts, configure a deployment branch (or pass `--branch`) if `release/*` branches exist to avoid ambiguous deployments.
+
+## Upgrading from 1.x
+
+Version 2.0 switches all database CLI invocations from `mysql` / `mysqldump` to `mariadb` / `mariadb-dump`. This is a breaking change: the affected tasks (`lameco:db_download`, `lameco:db_upload`, `lameco:sync`, `lameco:deactivate`) will fail with `command not found` on any host where only the legacy MySQL client is installed.
+
+To upgrade:
+
+1. Install the MariaDB client package locally and on every remote host that runs the database tasks.
+   - On Debian/Ubuntu: `apt install mariadb-client`.
+   - On macOS via Homebrew: `brew install mariadb`.
+2. If you cannot install the MariaDB client on a given host, create symlinks as a stopgap:
+   ```bash
+   ln -s "$(command -v mysql)"     /usr/local/bin/mariadb
+   ln -s "$(command -v mysqldump)" /usr/local/bin/mariadb-dump
+   ```
+3. The `MYSQL_PWD` environment variable is still used for password handling — the MariaDB client honors it for backward compatibility, so no credential changes are required.
+4. The `lameco:db_open` task still builds a `mysql://` URL for Sequel Ace; that is a Sequel Ace URL scheme and is unaffected.
 
 ## Contributing
 

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -95,7 +95,7 @@ task('lameco:db_download', function (): void {
         $remoteUserArg = escapeshellarg($remoteDatabaseUser);
         $remotePassEnv = escapeshellarg($remoteDatabasePassword);
         $remoteDbArg = escapeshellarg($remoteDatabaseName);
-        run('MYSQL_PWD=' . $remotePassEnv . ' mysqldump --quick --single-transaction -u ' . $remoteUserArg . ' ' . $remoteDbArg . ' | gzip > ' . $remotePathArg);
+        run('MYSQL_PWD=' . $remotePassEnv . ' mariadb-dump --quick --single-transaction -u ' . $remoteUserArg . ' ' . $remoteDbArg . ' | gzip > ' . $remotePathArg);
 
         writeln('Downloading database dump to local path: ' . $localPath . '...');
         download($remotePath, $localPath);
@@ -125,10 +125,10 @@ task('lameco:db_download', function (): void {
     $localPassEnv = escapeshellarg((string) $localDatabasePassword);
     $localDbName = str_replace('`', '``', $localDatabaseName);
     $createSql = 'DROP DATABASE IF EXISTS `' . $localDbName . '`; CREATE DATABASE `' . $localDbName . '`;';
-    runLocally('MYSQL_PWD=' . $localPassEnv . ' mysql -u ' . $localUserArg . ' -e ' . escapeshellarg($createSql));
+    runLocally('MYSQL_PWD=' . $localPassEnv . ' mariadb -u ' . $localUserArg . ' -e ' . escapeshellarg($createSql));
 
     writeln('Importing database dump into local database...');
-    runLocally('gunzip -c ' . $localPathArg . ' | MYSQL_PWD=' . $localPassEnv . ' mysql -u ' . $localUserArg . ' ' . escapeshellarg((string) $localDatabaseName));
+    runLocally('gunzip -c ' . $localPathArg . ' | MYSQL_PWD=' . $localPassEnv . ' mariadb -u ' . $localUserArg . ' ' . escapeshellarg((string) $localDatabaseName));
 
     writeln('Removing local dump file...');
     runLocally('rm ' . $localPathArg);
@@ -265,11 +265,11 @@ task('lameco:db_upload', function (): void {
         $remotePassEnv = escapeshellarg($remoteDatabasePassword);
         $remoteDbName = str_replace('`', '``', $remoteDatabaseName);
         $createSql = 'DROP DATABASE IF EXISTS `' . $remoteDbName . '`; CREATE DATABASE `' . $remoteDbName . '`;';
-        run('MYSQL_PWD=' . $remotePassEnv . ' mysql -u ' . $remoteUserArg . ' -e ' . escapeshellarg($createSql));
+        run('MYSQL_PWD=' . $remotePassEnv . ' mariadb -u ' . $remoteUserArg . ' -e ' . escapeshellarg($createSql));
 
         writeln('Importing database dump into remote database...');
         $remoteDbArg = escapeshellarg($remoteDatabaseName);
-        run('gunzip -c ' . $remotePathArg . ' | MYSQL_PWD=' . $remotePassEnv . ' mysql -u ' . $remoteUserArg . ' ' . $remoteDbArg);
+        run('gunzip -c ' . $remotePathArg . ' | MYSQL_PWD=' . $remotePassEnv . ' mariadb -u ' . $remoteUserArg . ' ' . $remoteDbArg);
 
         writeln('Removing remote dump file...');
         run('rm ' . $remotePathArg);
@@ -429,16 +429,16 @@ task('lameco:sync', function (): void {
         $destDbNameEscaped = str_replace('`', '``', $destDbName);
         $createSql = 'DROP DATABASE IF EXISTS `' . $destDbNameEscaped . '`; CREATE DATABASE `' . $destDbNameEscaped . '`;';
         $prepCmd = 'MYSQL_PWD=' . escapeshellarg((string) $destDbPassword)
-            . ' mysql -u ' . escapeshellarg((string) $destDbUser)
+            . ' mariadb -u ' . escapeshellarg((string) $destDbUser)
             . ' -e ' . escapeshellarg($createSql);
         runLocally($destSsh . ' ' . escapeshellarg($prepCmd));
 
         writeln('→ Streaming database from ' . $source . ' to ' . $destination . '...');
         $dumpCmd = 'MYSQL_PWD=' . escapeshellarg((string) $sourceDbPassword)
-            . ' mysqldump --quick --single-transaction -u ' . escapeshellarg((string) $sourceDbUser)
+            . ' mariadb-dump --quick --single-transaction -u ' . escapeshellarg((string) $sourceDbUser)
             . ' ' . escapeshellarg((string) $sourceDbName) . ' | gzip';
         $importCmd = 'gunzip | MYSQL_PWD=' . escapeshellarg((string) $destDbPassword)
-            . ' mysql -u ' . escapeshellarg((string) $destDbUser)
+            . ' mariadb -u ' . escapeshellarg((string) $destDbUser)
             . ' ' . escapeshellarg((string) $destDbName);
         runLocally(
             $sourceSsh . ' ' . escapeshellarg($dumpCmd) . ' | ' . $destSsh . ' ' . escapeshellarg($importCmd),
@@ -766,10 +766,10 @@ task('lameco:deactivate', function (): void {
             $dbArg = escapeshellarg($dbName);
 
             // Drop all tables but keep the database itself
-            $dropCmd = 'MYSQL_PWD=' . $passEnv . ' mysqldump --no-data -u ' . $userArg . ' ' . $dbArg
+            $dropCmd = 'MYSQL_PWD=' . $passEnv . ' mariadb-dump --no-data -u ' . $userArg . ' ' . $dbArg
                 . ' | grep "^DROP"'
                 . ' | (echo "SET FOREIGN_KEY_CHECKS=0;"; cat; echo "SET FOREIGN_KEY_CHECKS=1;")'
-                . ' | MYSQL_PWD=' . $passEnv . ' mysql -u ' . $userArg . ' ' . $dbArg;
+                . ' | MYSQL_PWD=' . $passEnv . ' mariadb -u ' . $userArg . ' ' . $dbArg;
             run($dropCmd);
             writeln('  Alle tabellen in "' . $dbName . '" verwijderd.');
         });


### PR DESCRIPTION
## Summary

- Switches every `mysql` / `mysqldump` invocation in `src/tasks.php` to `mariadb` / `mariadb-dump`. The affected tasks are `lameco:db_download`, `lameco:db_upload`, `lameco:sync`, and `lameco:deactivate`.
- Preserves the `MYSQL_PWD` env-var convention (the MariaDB client still honors it).
- Preserves the `mysql://` URL in `lameco:db_open` — that is a Sequel Ace URL scheme, not a CLI invocation.
- Adds a Requirements bullet and an "Upgrading from 1.x" section to the README documenting the new client requirement and a symlink workaround for hosts that only ship the legacy MySQL client.

## Breaking change

Hosts running the affected tasks must now have the MariaDB client installed (`apt install mariadb-client` on Debian/Ubuntu, `brew install mariadb` on macOS). The `feat!:` marker on the commit will cause release-please to bump the next release to **2.0.0**.

## Test plan

- [ ] Install this branch in a downstream project (`composer require lameco/deployer-tasks:dev-feat/mariadb-client`).
- [ ] Run `dep lameco:db_download` against a host with `mariadb-client` installed and confirm the dump completes and imports locally.
- [ ] Run `dep lameco:db_upload` and `dep lameco:sync` and confirm the same.
- [ ] On a host that lacks the `mariadb` binary, confirm the task fails fast with `command not found` (intentional — surfaces the new requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)