### PR TITLE
feat: support Deployer 8 alongside Deployer 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.4",
-        "deployer/deployer": "^7.0"
+        "deployer/deployer": "^7.0 || ^8.0"
     },
     "require-dev": {
         "rector/rector": "^2.2",

--- a/src/functions.php
+++ b/src/functions.php
@@ -213,10 +213,39 @@ function composerHasPackage(string $package): bool
  */
 function buildSshCommand(\Deployer\Host\Host $host): string
 {
-    $options = $host->connectionOptionsString();
+    // Deployer 8 removed Host::connectionOptionsString()/connectionOptionsArray();
+    // only connectionOptions(): array remains. Reproduce v7's exact formatting
+    // (implode of escapeshellarg'd flags) from whichever accessor the engine exposes.
+    $optionsArray = method_exists($host, 'connectionOptions')
+        ? $host->connectionOptions()        // Deployer 8
+        : $host->connectionOptionsArray();  // Deployer 7
+    $options = implode(' ', array_map(escapeshellarg(...), $optionsArray));
     $connection = escapeshellarg($host->connectionString());
 
     return 'ssh' . ($options !== '' ? ' ' . $options : '') . ' ' . $connection;
+}
+
+/**
+ * Run a command locally with no timeout, compatible with Deployer 7 and 8.
+ *
+ * Deployer 7's runLocally() accepts an options array as its 2nd positional
+ * argument (['timeout' => null]); Deployer 8 removed that form (the 2nd/3rd
+ * positionals are now ?string $cwd / ?int $timeout). Branch on the v8-only
+ * Host::connectionOptions() to pick the correct call shape; 0 disables the
+ * timeout identically to v7's null.
+ *
+ * @param string $command The command to run locally.
+ * @return string The command output.
+ */
+function runLocallyWithoutTimeout(string $command): string
+{
+    if (method_exists(\Deployer\Host\Host::class, 'connectionOptions')) {
+        return runLocally($command, null, 0);
+    }
+
+    return runLocally($command, [
+        'timeout' => null,
+    ]);
 }
 
 /**

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -440,11 +440,8 @@ task('lameco:sync', function (): void {
         $importCmd = 'gunzip | MYSQL_PWD=' . escapeshellarg((string) $destDbPassword)
             . ' mariadb -u ' . escapeshellarg((string) $destDbUser)
             . ' ' . escapeshellarg((string) $destDbName);
-        runLocally(
+        runLocallyWithoutTimeout(
             $sourceSsh . ' ' . escapeshellarg($dumpCmd) . ' | ' . $destSsh . ' ' . escapeshellarg($importCmd),
-            [
-                'timeout' => null,
-            ],
         );
     }
 
@@ -475,11 +472,8 @@ task('lameco:sync', function (): void {
 
                 $tarSource = 'tar czf - -C ' . escapeshellarg($sourceDeployPath . '/shared') . ' ' . escapeshellarg($dir);
                 $tarDest = 'tar xzf - -C ' . escapeshellarg($destDeployPath . '/shared');
-                runLocally(
+                runLocallyWithoutTimeout(
                     $sourceSsh . ' ' . escapeshellarg($tarSource) . ' | ' . $destSsh . ' ' . escapeshellarg($tarDest),
-                    [
-                        'timeout' => null,
-                    ],
                 );
             }
         }


### PR DESCRIPTION
## Description

Makes `lameco/deployer-tasks` work on **Deployer 8** while keeping **Deployer 7** — a backward-compatible (minor) change. Enables a per-repo Deployer 8 opt-in (e.g. for `update_code_strategy: local_archive`) without forcing any consumer to upgrade.

## Why minor, not major

`^7.0` → `^7.0 || ^8.0` is a superset that forces nobody off v7 — Symfony-6 repos keep resolving Deployer 7 (v8 requires `symfony/console ^7.4||^8`); only repos already on Symfony 7.4+ that *opt in* (by widening their own deployer pin) get v8. v7 behaviour is byte-identical. release-please will bump 2.0.0 → **2.1.0**.

## Changes

- **composer.json**: `deployer/deployer` → `^7.0 || ^8.0`.
- **functions.php `buildSshCommand()`**: `Host::connectionOptionsString()` was removed in Deployer 8 (only `connectionOptions(): array` remains). `method_exists` guard reproduces v7's exact `escapeshellarg` formatting from whichever accessor exists.
- **functions.php**: new `runLocallyWithoutTimeout()` helper (version-guarded — v7 `['timeout'=>null]` vs v8 `(cwd: null, timeout: 0)`).
- **tasks.php**: the two `lameco:sync` pipes (DB stream, tar stream) use the helper instead of the removed options-array form.

All three breaking sites were confirmed by an exhaustive audit (171 DSL calls reviewed, completeness-checked) to be the only ones, and all are off the deploy path.

## Validation

- ✅ `php -l`, ECS clean, `composer validate` valid
- ✅ Rector adds **no** new findings (only the pre-existing `tasks.php` `$phpConfig` cast remains — left out of scope)
- ✅ `composer install` resolves `deployer/deployer v8.0.5` cleanly under the new constraint

## ⚠️ Before tagging — smoke-test on a real Deployer 8 install

A green `dep deploy` does **not** exercise the fixes (they're off-path). Please run on a v8 staging:
- [ ] full `dep deploy`
- [ ] `dep lameco:sync` (DB **and** files)
- [ ] verify the generated SSH prefix from `connectionOptions()` (v8) matches v7 for a non-trivial host (custom port / identity file / ProxyJump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)