### PR TITLE
feat: back up the database before migrating on deploy

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -111,3 +111,9 @@ set('lameco_supervisor_configs', ['{{http_user}}.conf']);
 
 set('lameco_restart_php', true);
 set('lameco_php_config', 'php-fpm-{{http_user}}.service');
+
+// Take a gzipped mariadb-dump of the live database into shared/backups before
+// running migrations on deploy. This is the real recovery path: `dep rollback`
+// only repoints the code symlink and down() migrations are often lossy.
+set('lameco_db_backup_on_deploy', true);
+set('lameco_db_backup_keep', 5);

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -153,6 +153,40 @@ task('lameco:db_credentials', function (): void {
     });
 });
 
+// Back up the remote database into shared/backups, keeping the newest N.
+desc('Back up the remote database into shared/backups (keeps the newest N)');
+task('lameco:db_backup', function (): void {
+    within('{{deploy_path}}/shared', function (): void {
+        $env = fetchEnv(run('cat .env'));
+
+        [$dbUser, $dbPassword, $dbName] = extractDbCredentials($env);
+
+        if (! isset($dbUser, $dbPassword, $dbName)) {
+            // Fail the deploy rather than migrate without a backup. Set
+            // lameco_db_backup_on_deploy to false to opt out deliberately.
+            error('Could not extract remote database credentials — refusing to migrate without a backup.');
+            throw new GracefulShutdownException('Database backup aborted: missing credentials.');
+        }
+
+        writeln('Backing up database "' . $dbName . '" to shared/backups...');
+        // Pass the name through a shell var so it is safely quoted in both the
+        // dump argument and the timestamped filename (which needs $(date) live).
+        run(
+            'DB=' . escapeshellarg($dbName) . '; '
+            . 'mkdir -p backups && '
+            . 'MYSQL_PWD=' . escapeshellarg($dbPassword) . ' mariadb-dump --quick --single-transaction -u '
+            . escapeshellarg($dbUser) . ' "$DB" '
+            . '| gzip > "backups/${DB}_$(date +%Y%m%d_%H%M%S).sql.gz"',
+        );
+
+        $keep = (int) get('lameco_db_backup_keep');
+        if ($keep > 0) {
+            writeln('Pruning old backups (keeping newest ' . $keep . ')...');
+            run('ls -1t backups/*.sql.gz 2>/dev/null | tail -n +' . ($keep + 1) . ' | xargs -r rm -f');
+        }
+    });
+});
+
 // Open the remote database in Sequel Ace via SSH tunnel.
 desc('Open the remote database in Sequel Ace via SSH tunnel');
 task('lameco:db_open', function (): void {
@@ -891,4 +925,7 @@ after('deploy:success', 'lameco:update_htpasswd');
 
 if (in_array(get('lameco_project_type'), ['symfony', 'kunstmaan'], true)) {
     before('deploy:symlink', 'database:migrate');
+    if (get('lameco_db_backup_on_deploy')) {
+        before('database:migrate', 'lameco:db_backup');
+    }
 }


### PR DESCRIPTION
## Description

Symfony/Kunstmaan deploys already run `database:migrate` (`before('deploy:symlink', 'database:migrate')`) — but with **no backup**. `dep rollback` only repoints the code symlink, and `down()` migrations are frequently lossy, so a failed or destructive migration on prod has no recovery path. This is the real blocker before enabling auto-deploy to production.

Adds `lameco:db_backup` and hooks it **before** `database:migrate`, so every migrating deploy is preceded by a restorable dump.

## Changes

- **`lameco:db_backup`** — gzipped `mariadb-dump --quick --single-transaction` into `shared/backups/<db>_<timestamp>.sql.gz`, prunes to the newest N. Reuses the existing `fetchEnv` / `extractDbCredentials` helpers; DB name passed via a shell var so it's safely quoted. Halts the deploy if credentials can't be read (won't migrate without a backup).
- **Hook** — `before('database:migrate', 'lameco:db_backup')`, only for symfony/kunstmaan and only when enabled.
- **Settings** — `lameco_db_backup_on_deploy` (default `true`), `lameco_db_backup_keep` (default `5`).

## Type of Change

- [x] New feature (safety; default-on, opt-out via setting)

## Testing

- [x] `php -l` clean, `vendor/bin/ecs check` clean.
- Recommend validating on a **staging** deploy first (small DB): confirm `shared/backups/` fills and prunes, then enable confidence for prod.

## Notes

- Craft/Laravel don't auto-migrate today (no `database:migrate` hook), so they get no pre-migrate backup. If/when Craft `craft up`-on-deploy is added, pair it with this task the same way.
- Pair with **expand/contract migration discipline** — the backup is recovery, not a substitute for backward-compatible migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)